### PR TITLE
chore: assign `tool` profile to `migrate` service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,3 +15,5 @@ services:
     pull_policy: build
     env_file: .env
     restart: no
+    profiles:
+      - tools


### PR DESCRIPTION
see: https://docs.docker.com/compose/profiles/